### PR TITLE
nep-Y: add missing return error codes

### DIFF
--- a/nep-Y.mediawiki
+++ b/nep-Y.mediawiki
@@ -290,7 +290,7 @@ Neo-specific codes are documented here, generic JSON-RPC errors like -32602 or
 |-
 | submitblock         || -500, -501, -508, -509
 |-
-| submitoracleresponse|| -602, -603, -604, -605
+| submitoracleresponse|| -508, -602, -603, -604, -605
 |-
 | terminatesession    || -107, -601
 |-

--- a/nep-Y.mediawiki
+++ b/nep-Y.mediawiki
@@ -288,7 +288,7 @@ Neo-specific codes are documented here, generic JSON-RPC errors like -32602 or
 |-
 | sendrawtransaction  || -500, -501, -502, -503, -504, -505, -506, -507, -508, -509, -510, -511
 |-
-| submitblock         || -500, -501, -508, -509
+| submitblock         || -500, -501, -502, -503, -504, -505, -506, -507, -508, -509, -510, -511
 |-
 | submitoracleresponse|| -508, -602, -603, -604, -605
 |-

--- a/nep-Y.mediawiki
+++ b/nep-Y.mediawiki
@@ -298,7 +298,7 @@ Neo-specific codes are documented here, generic JSON-RPC errors like -32602 or
 |-
 | validateaddress     ||
 |-
-| verifyproof         || -607
+| verifyproof         || -606, -607
 |}
 
 

--- a/nep-Y.mediawiki
+++ b/nep-Y.mediawiki
@@ -210,11 +210,11 @@ Neo-specific codes are documented here, generic JSON-RPC errors like -32602 or
 |-
 | getapplicationlog   || -105
 |-
-| getblock            || -101
+| getblock            || -101, -109
 |-
 | getblockhash        || -109
 |-
-| getblockheader      || -101
+| getblockheader      || -101, -109
 |-
 | getcandidates       ||
 |-


### PR DESCRIPTION
Based on the
https://docs.google.com/spreadsheets/d/1VShwR1qdVeE7J4gGUBzSPnjAIWkhXb-VT9yvf9cau6I/edit#gid=0 and https://github.com/nspcc-dev/neo-go/pull/3063.

I've added comments to the table wrt the rest of issues specified in the https://docs.google.com/spreadsheets/d/1VShwR1qdVeE7J4gGUBzSPnjAIWkhXb-VT9yvf9cau6I/edit#gid=0.